### PR TITLE
compilation error issue due to wrong verions of em module

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,15 +36,5 @@ COPY ./build-android.sh /home/${USERNAME}/
 RUN chmod +x /home/${USERNAME}/build-android.sh
 
 
-#Android SDK
-#only needed if you want to build android related packages
-#ENV ANDROID_SDK_ROOT "/opt/android/sdk"
-#ENV ANDROID_HOME "/opt/android/sdk"
-#RUN mkdir -p ${ANDROID_SDK_ROOT}/cmdline-tools
-#RUN wget -O /tmp/android-sdk.zip https://dl.google.com/android/repository/commandlinetools-linux-8092744_latest.zip && unzip /tmp/android-sdk.zip -d $ANDROID_SDK_ROOT/cmdline-tools && mv ${ANDROID_SDK_ROOT}/cmdline-tools/cmdline-tools ${ANDROID_SDK_ROOT}/cmdline-tools/tools && rm /tmp/android-sdk.zip
-
-#RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --licenses
-#RUN yes | ${ANDROID_SDK_ROOT}/cmdline-tools/tools/bin/sdkmanager --verbose "platform-tools" "platforms;${ANDROID_TARGET}"
-
 USER $USERNAME
 WORKDIR /home/$USERNAME/

--- a/build-android.sh
+++ b/build-android.sh
@@ -7,6 +7,9 @@ export PYTHON3_EXEC="$( which python3 )"
 export PYTHON3_LIBRARY="$( ${PYTHON3_EXEC} -c 'import os.path; from distutils import sysconfig; print(os.path.realpath(os.path.join(sysconfig.get_config_var("LIBPL"), sysconfig.get_config_var("LDLIBRARY"))))' )"
 export PYTHON3_INCLUDE_DIR="$( ${PYTHON3_EXEC} -c 'from distutils import sysconfig; print(sysconfig.get_config_var("INCLUDEPY"))' )"
 
+sudo pip3 uninstall em
+sudo pip install empy==3.3.4
+
 colcon build \
     --packages-ignore cyclonedds rcl_logging_log4cxx rcl_logging_spdlog rosidl_generator_py rclandroid ros2_talker_android ros2_listener_android \
     --cmake-args \


### PR DESCRIPTION
To properly compile the ros2java the em module must be remove and empy version 3.3.4 must be installed